### PR TITLE
hotfix/element-label-attribute-class

### DIFF
--- a/src/ZfcTwitterBootstrap/Form/View/Helper/FormElementWrapper.php
+++ b/src/ZfcTwitterBootstrap/Form/View/Helper/FormElementWrapper.php
@@ -264,13 +264,17 @@ class FormElementWrapper extends FormElement
             $html .= $escapeHelper($label);
             $html .= $labelHelper->closeTag();
         }
+
+        $elementHelper->getView()->plugin('form_radio')->setLabelAttributes(array(
+            'class' => $element->getAttribute('type'),
+        ));
+
         $html .= sprintf($controlWrapper,
             $id,
             $elementHelper->render($element),
             $descriptionHelper->render($element),
             $elementErrorHelper->render($element)
         );
-
 
         $addtClass = ($element->getMessages()) ? ' error' : '';
         return sprintf($groupWrapper, $addtClass, $id, $html);


### PR DESCRIPTION
Adds the element attribute's type to the input labels to fix display issues with things like radio and checkboxes.
