### PR TITLE
ZF2 2.0.2 changes and bootstrap updates

### DIFF
--- a/src/ZfcTwitterBootstrap/Form/View/Helper/FormDescription.php
+++ b/src/ZfcTwitterBootstrap/Form/View/Helper/FormDescription.php
@@ -89,10 +89,10 @@ class FormDescription extends AbstractHelper
         $inlineWrapper = $inlineWrapper ?: $this->inlineWrapper;
 
         $html = '';
-        if ($inline = $element->getAttribute('help-inline')) {
+        if ($inline = $element->getOption('help-inline')) {
             $html .= sprintf($inlineWrapper, $inline);
         }
-        if ($block = $element->getAttribute('help-block')) {
+        if ($block = $element->getOption('help-block')) {
             $html .= sprintf($blockWrapper, $block);
         }
         return $html;

--- a/src/ZfcTwitterBootstrap/Form/View/Helper/FormElementWrapper.php
+++ b/src/ZfcTwitterBootstrap/Form/View/Helper/FormElementWrapper.php
@@ -250,11 +250,12 @@ class FormElementWrapper extends FormElement
         $descriptionHelper = $this->getDescriptionHelper();
         $groupWrapper = $groupWrapper ?: $this->groupWrapper;
         $controlWrapper = $controlWrapper ?: $this->controlWrapper;
+        $renderer = $elementHelper->getView();
 
         $id = $element->getAttribute('id') ?: $element->getAttribute('name');
         $html = "";
 
-        $label = $element->getAttribute('label');
+        $label = $element->getOption('label') ?: $element->getAttribute('label');
         if ($label) {
             $html .= $labelHelper->openTag(array(
                 'for' => $id,
@@ -264,13 +265,21 @@ class FormElementWrapper extends FormElement
             $html .= $escapeHelper($label);
             $html .= $labelHelper->closeTag();
         }
+
+        if (method_exists($renderer, 'plugin')) {
+            if ($element instanceof \Zend\Form\Element\Radio) {
+                $renderer->plugin('form_radio')->setLabelAttributes(array(
+                    'class' => 'radio',
+                ));
+            }
+        }
+
         $html .= sprintf($controlWrapper,
             $id,
             $elementHelper->render($element),
             $descriptionHelper->render($element),
             $elementErrorHelper->render($element)
         );
-
 
         $addtClass = ($element->getMessages()) ? ' error' : '';
         return sprintf($groupWrapper, $addtClass, $id, $html);


### PR DESCRIPTION
- Proposing a new class for radio button labels to center the text vertically.
- Looking for the label value in options instead of attributes (ZF2 late RC-change).
- Moving other options from attributes to options (info labels and descriptions).
