### PR TITLE
Typo in module.config.php

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -1,5 +1,6 @@
 <?php
 return array(
+    'view_helpers' => array(
         'invokables' => array(
             'ztbalert'           => 'ZfcTwitterBootstrap\View\Helper\Alert',
             'ztbbadge'           => 'ZfcTwitterBootstrap\View\Helper\Badge',


### PR DESCRIPTION
Looks like you moved the formElementError view helper to the module; but when you removed the block from the config you also removed the parent index which puts a nice syntax error in the file.
