### PR TITLE
Menu dropdowns usage is a bit broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /*.project
 /*vendor
 /*composer.lock
+/.idea

--- a/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
@@ -77,10 +77,7 @@ class Menu extends ZendMenu
             if ($subPage->isActive(true)) {
                 $liClasses[] = 'active';
             }
-            // Is page parent?
-            if ($subPage->hasPages()) {
-                $liClasses[] = 'dropdown';
-            }
+
             // Add CSS class from page to <li>
             if ($addClassToListItem && $subPage->getClass()) {
                 $liClasses[] = $subPage->getClass();

--- a/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
@@ -177,7 +177,7 @@ class Menu extends ZendMenu
                 // start new ul tag
                 if ($ulClass && $depth ==  0) {
                     $ulClass = ' class="' . $ulClass . '"';
-                } else if ($page->getParent()) {
+                } elseif ($page->getParent()) {
                     $ulClass = ' class="dropdown-menu"';
                 } else {
                     $ulClass = '';

--- a/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
@@ -204,7 +204,7 @@ class Menu extends ZendMenu
                 $liClasses[] = 'active';
             }
             // Is page parent?
-            if ($page->hasChildren() && $depth < $maxDepth) {
+            if ($page->hasChildren() && (!isset($maxDepth) || $depth < $maxDepth)) {
                 $liClasses[] = 'dropdown';
                 $page->isDropdown = true;
             }

--- a/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
@@ -204,8 +204,9 @@ class Menu extends ZendMenu
                 $liClasses[] = 'active';
             }
             // Is page parent?
-            if ($page->hasChildren()) {
+            if ($page->hasChildren() && $depth < $maxDepth) {
                 $liClasses[] = 'dropdown';
+                $page->isDropdown = true;
             }
             // Add CSS class from page to <li>
             if ($addClassToListItem && $page->getClass()) {
@@ -274,7 +275,7 @@ class Menu extends ZendMenu
         if ($addClassToListItem === false) {
             $class[] = $page->getClass();
         }
-        if ($page->hasChildren()) {
+        if ($page->isDropdown) {
             $attribs['data-toggle'] = 'dropdown';
             $class[] = 'dropdown-toggle';
             $extended = '<b class="caret"></b>';

--- a/tests/ZfcTwitterBootstrap/View/Helper/Navigation/MenuTest.php
+++ b/tests/ZfcTwitterBootstrap/View/Helper/Navigation/MenuTest.php
@@ -1,0 +1,196 @@
+<?php
+namespace ZfcTwitterBootstrapTest\View\Helper\Navigation;
+
+use ZfcTwitterBootstrap\View\Helper\Navigation\Menu;
+
+class MenuTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Menu
+     */
+    protected $helper;
+
+    public function setUp()
+    {
+        $this->helper = new Menu();
+        $this->helper->setView(new \Zend\View\Renderer\PhpRenderer());
+        $this->helper->getView()->plugin('basePath')->setBasePath('/');
+    }
+
+    public function testDropdownWithMaxDepth()
+    {
+        $container = new \Zend\Navigation\Navigation(array(
+            array(
+                'label' => 'Page 1',
+                'id'    => 'p1',
+                'uri'   => 'p1',
+            ),
+            array(
+                'label' => 'Page 2',
+                'id'    => 'p2',
+                'uri'   => 'p2',
+                'pages' => array(
+                    array(
+                        'label' => 'Page 2.1',
+                        'id'    => 'p2-1',
+                        'uri'   => 'p2-1',
+                        'pages' => array(
+                            array(
+                                'label' => 'Page 2.1.1',
+                                'id'    => 'p2-1-1',
+                                'uri'   => 'p2-1-1',
+                            ),
+                            array(
+                                'label' => 'Page 2.1.2',
+                                'id'    => 'p2-1-2',
+                                'uri'   => 'p2-1-2',
+                            ),
+                        ),
+                    ),
+                    array(
+                        'label' => 'Page 2.2',
+                        'id'    => 'p2-2',
+                        'uri'   => 'p2-2',
+                    ),
+                ),
+            ),
+        ));
+        $expected = '<ul class="nav">
+    <li>
+        <a id="menu-p1" href="p1">Page 1</a>
+    </li>
+    <li class="dropdown">
+        <a id="menu-p2" href="p2" data-toggle="dropdown" class=" dropdown-toggle">Page 2<b class="caret"></b></a>
+        <ul class="dropdown-menu">
+            <li>
+                <a id="menu-p2-1" href="p2-1">Page 2.1</a>
+            </li>
+            <li>
+                <a id="menu-p2-2" href="p2-2">Page 2.2</a>
+            </li>
+        </ul>
+    </li>
+</ul>';
+
+        $this->helper->setMaxDepth(1);
+        $actual = $this->helper->renderMenu($container);
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testRenderDeepestMenu()
+    {
+
+        $container = new \Zend\Navigation\Navigation(array(
+            array(
+                'label' => 'Page 1',
+                'id'    => 'p1',
+                'uri'   => 'p1',
+            ),
+            array(
+                'label' => 'Page 2',
+                'id'    => 'p2',
+                'uri'   => 'p2',
+                'pages' => array(
+                    array(
+                        'label' => 'Page 2.1',
+                        'id'    => 'p2-1',
+                        'uri'   => 'p2-1',
+                        'pages' => array(
+                            array(
+                                'label' => 'Page 2.1.1',
+                                'id'    => 'p2-1-1',
+                                'uri'   => 'p2-1-1',
+                                'active' => true,
+                            ),
+                            array(
+                                'label' => 'Page 2.1.2',
+                                'id'    => 'p2-1-2',
+                                'uri'   => 'p2-1-2',
+                            ),
+                        ),
+                    ),
+                    array(
+                        'label' => 'Page 2.2',
+                        'id'    => 'p2-2',
+                        'uri'   => 'p2-2',
+                    ),
+                ),
+            ),
+        ));
+        $expected = '<ul class="nav">
+    <li class="active">
+        <a id="menu-p2-1-1" href="p2-1-1">Page 2.1.1</a>
+    </li>
+    <li>
+        <a id="menu-p2-1-2" href="p2-1-2">Page 2.1.2</a>
+    </li>
+</ul>';
+
+
+        $this->helper->setOnlyActiveBranch(true);
+        $this->helper->setRenderParents(false);
+        $actual = $this->helper->renderMenu($container);
+
+        $actual = $this->helper->render($container);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testNoDropdownWhenRenderingDeepestMenu()
+    {
+
+        $container = new \Zend\Navigation\Navigation(array(
+            array(
+                'label' => 'Page 1',
+                'id'    => 'p1',
+                'uri'   => 'p1',
+            ),
+            array(
+                'label' => 'Page 2',
+                'id'    => 'p2',
+                'uri'   => 'p2',
+                'pages' => array(
+                    array(
+                        'label' => 'Page 2.1',
+                        'id'    => 'p2-1',
+                        'uri'   => 'p2-1',
+                        'pages' => array(
+                            array(
+                                'label' => 'Page 2.1.1',
+                                'id'    => 'p2-1-1',
+                                'uri'   => 'p2-1-1',
+                                'active' => true,
+                            ),
+                            array(
+                                'label' => 'Page 2.1.2',
+                                'id'    => 'p2-1-2',
+                                'uri'   => 'p2-1-2',
+                            ),
+                        ),
+                    ),
+                    array(
+                        'label' => 'Page 2.2',
+                        'id'    => 'p2-2',
+                        'uri'   => 'p2-2',
+                    ),
+                ),
+            ),
+        ));
+        $expected = '<ul class="nav">
+    <li class="active">
+        <a id="menu-p2-1" href="p2-1">Page 2.1</a>
+    </li>
+    <li>
+        <a id="menu-p2-2" href="p2-2">Page 2.2</a>
+    </li>
+</ul>';
+
+        $this->helper->setOnlyActiveBranch(true);
+        $this->helper->setRenderParents(false);
+        $this->helper->setMaxDepth(1);
+        $actual = $this->helper->renderMenu($container);
+
+        $actual = $this->helper->render($container);
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This PR fixes dropdown usage when using `maxDepth` and `onlyActiveBranch` options.

Basically you don't want the dropdown toggle anchor if the current most deep page also has children that will not be rendered.

Also the `renderDeepestMenu` method doesn't need to add dropdown classes at all, since it only renders a single level.

It may be worth noting that AFAIK Twitter Bootstrap doesn't handle nested dropdowns anyway, they are limited to 2 level nesting, so at the moment `setMaxDepth(1)` is the way to prevent the undesired markup. I'd like to know if and how you want me to address the problem.
