### PR TITLE
Update Menu.php

### DIFF
--- a/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
@@ -202,8 +202,13 @@ class Menu extends ZendMenu
             }
             // Is page parent?
             if ($page->hasChildren() && (!isset($maxDepth) || $depth < $maxDepth)) {
-                $liClasses[] = 'dropdown';
-                $page->isDropdown = true;
+                if (!isset($page->get('dropdown')) && $page->get('dropdown') !== false) {
+                    $liClasses[] = 'dropdown';
+                    $page->isDropdown = true;
+                } else if (!isset($page->get('dropdown')) {
+                    $liClasses[] = 'dropdown';
+                    $page->isDropdown = true;
+                }
             }
             // Add CSS class from page to <li>
             if ($addClassToListItem && $page->getClass()) {

--- a/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
@@ -202,10 +202,7 @@ class Menu extends ZendMenu
             }
             // Is page parent?
             if ($page->hasChildren() && (!isset($maxDepth) || $depth < $maxDepth)) {
-                if (!isset($page->get('dropdown')) && $page->get('dropdown') !== false) {
-                    $liClasses[] = 'dropdown';
-                    $page->isDropdown = true;
-                } else if (!isset($page->get('dropdown')) {
+                if (!isset($page->dropdown) || $page->dropdown == true) {
                     $liClasses[] = 'dropdown';
                     $page->isDropdown = true;
                 }


### PR DESCRIPTION
Allow to use `dropdown` attribute on Mvc and Uri pages to disable dropdown menu on links. Useful when subpages are hidden.

Usage:

```
$page = array(
    'label' => 'LABEL',
    'route' => 'home',
    'pages' => array(...),
    'dropdown' => false,
);
```
