### PR TITLE
Update Menu.php to add space before caret

### DIFF
--- a/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Navigation/Menu.php
@@ -275,7 +275,7 @@ class Menu extends ZendMenu
         if ($page->isDropdown) {
             $attribs['data-toggle'] = 'dropdown';
             $class[] = 'dropdown-toggle';
-            $extended = '<b class="caret"></b>';
+            $extended = ' <b class="caret"></b>';
         }
         if (count($class) > 0) {
             $attribs['class'] = implode(' ', $class);

--- a/tests/ZfcTwitterBootstrap/View/Helper/Navigation/MenuTest.php
+++ b/tests/ZfcTwitterBootstrap/View/Helper/Navigation/MenuTest.php
@@ -60,7 +60,7 @@ class MenuTest extends \PHPUnit_Framework_TestCase
         <a id="menu-p1" href="p1">Page 1</a>
     </li>
     <li class="dropdown">
-        <a id="menu-p2" href="p2" data-toggle="dropdown" class=" dropdown-toggle">Page 2<b class="caret"></b></a>
+        <a id="menu-p2" href="p2" data-toggle="dropdown" class=" dropdown-toggle">Page 2 <b class="caret"></b></a>
         <ul class="dropdown-menu">
             <li>
                 <a id="menu-p2-1" href="p2-1">Page 2.1</a>

--- a/tests/ZfcTwitterBootstrap/View/Helper/NavigationTest.php
+++ b/tests/ZfcTwitterBootstrap/View/Helper/NavigationTest.php
@@ -76,7 +76,7 @@ class NavigationTest extends \PHPUnit_Framework_TestCase
         <a id="menu-p1" href="p1">Page 1</a>
     </li>
     <li class="dropdown">
-        <a id="menu-p2" href="p2" data-toggle="dropdown" class=" dropdown-toggle">Page 2<b class="caret"></b></a>
+        <a id="menu-p2" href="p2" data-toggle="dropdown" class=" dropdown-toggle">Page 2 <b class="caret"></b></a>
         <ul class="dropdown-menu">
             <li>
                 <a id="menu-p2-1" href="p2-1">Page 2.1</a>


### PR DESCRIPTION
According to Bootstrap documentation a space must be left before or after the "icons" and caret. Otherwise icons/carets will stick to the text (since they are text themselves).
