### PR TITLE
Update class for Bootstrap 3.

### DIFF
--- a/src/ZfcTwitterBootstrap/View/Helper/Alert.php
+++ b/src/ZfcTwitterBootstrap/View/Helper/Alert.php
@@ -41,7 +41,7 @@ FORMAT;
      */
     public function error($alert, $isBlock = false)
     {
-        return $this->render($alert, $isBlock, 'alert-error');
+        return $this->render($alert, $isBlock, 'alert-danger');
     }
 
     /**


### PR DESCRIPTION
Can't see in your documentation which version(s) of Bootstrap this module is intended to support?... I'm using it with Bootstrap 3 so need to update class "error" to "danger".
